### PR TITLE
Including SwiftJavaRuntimeSupport on SwiftHashing dependencies.

### DIFF
--- a/hello-swift-java/hashing-lib/Package.swift
+++ b/hello-swift-java/hashing-lib/Package.swift
@@ -60,6 +60,7 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto"),
         .product(name: "SwiftJava", package: "swift-java"),
         .product(name: "CSwiftJavaJNI", package: "swift-java"),
+        .product(name: "SwiftJavaRuntimeSupport", package: "swift-java"),
       ],
       swiftSettings: [
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"], .when(platforms: [.macOS, .linux, .windows]))


### PR DESCRIPTION
Including SwiftJavaRuntimeSupport in the dependency list as it seems to be imported by the generated swift files.

Building the hashing-lib example the following error is throwing
```
[125/128] Compiling SwiftHashing SwiftHashing.swift
  7 | import SwiftJava
  8 | import CSwiftJavaJNI
  9 | import SwiftJavaRuntimeSupport
    |        `- error: no such module 'SwiftJavaRuntimeSupport'
 10 | 
```