### PR TITLE
Update hashing-example to Java 17 compatibility

### DIFF
--- a/hello-swift-java/hashing-app/build.gradle.kts
+++ b/hello-swift-java/hashing-app/build.gradle.kts
@@ -28,11 +28,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/hello-swift-java/hashing-lib/build.gradle
+++ b/hello-swift-java/hashing-lib/build.gradle
@@ -14,11 +14,11 @@ android {
     defaultConfig {
         minSdkVersion 28
     }
-}
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
 }
 
 dependencies {


### PR DESCRIPTION
The `swift-java` tool generates code that requires 17 language features. JDK 17 support was [added in Android 14](https://developer.android.com/about/versions/14/features#core-libraries).

So we update the Java bytecode version of the sample app, so people don't have to figure out by themselves.