### PR TITLE
Add v5 language mode flag

### DIFF
--- a/hello-swift-java/hashing-lib/Package.swift
+++ b/hello-swift-java/hashing-lib/Package.swift
@@ -63,6 +63,7 @@ let package = Package(
         .product(name: "SwiftJavaRuntimeSupport", package: "swift-java"),
       ],
       swiftSettings: [
+        .swiftLanguageMode(.v5),
         .unsafeFlags(["-I\(javaIncludePath)", "-I\(javaPlatformIncludePath)"], .when(platforms: [.macOS, .linux, .windows]))
       ],
       plugins: [


### PR DESCRIPTION
We need that for now because of `sending` issues with async functions.