### PR TITLE
Matching swift sdks with install instruction version

### DIFF
--- a/hello-cpp-swift/swift-lib/build.gradle
+++ b/hello-cpp-swift/swift-lib/build.gradle
@@ -89,8 +89,8 @@ def swiftRuntimeLibs = [
     "swiftSynchronization"
 ]
 
-def sdkName = "swift-DEVELOPMENT-SNAPSHOT-2025-12-17-a_android.artifactbundle"
-def swiftVersion = "main-snapshot-2025-12-17"
+def sdkName = "swift-DEVELOPMENT-SNAPSHOT-2026-01-07-a_android.artifactbundle"
+def swiftVersion = "main-snapshot-2026-01-07"
 def minSdk = android.defaultConfig.minSdkVersion.apiLevel
 
 def abis = [

--- a/hello-swift-java/hashing-lib/build.gradle
+++ b/hello-swift-java/hashing-lib/build.gradle
@@ -99,8 +99,8 @@ def swiftRuntimeLibs = [
     "swiftSynchronization"
 ]
 
-def sdkName = "swift-DEVELOPMENT-SNAPSHOT-2025-12-17-a_android.artifactbundle"
-def swiftVersion = "main-snapshot-2025-12-17"
+def sdkName = "swift-DEVELOPMENT-SNAPSHOT-2026-01-07-a_android.artifactbundle"
+def swiftVersion = "main-snapshot-2026-01-07"
 def minSdk = android.defaultConfig.minSdkVersion.apiLevel
 /**
  * Android ABIs and their Swift triple mappings

--- a/swift-android.gradle.kts
+++ b/swift-android.gradle.kts
@@ -14,8 +14,8 @@ data class SwiftConfig(
     var releaseExtraBuildFlags: List<String> = emptyList(),
     var swiftlyPath: String? = null, // Optional custom swiftly path
     var swiftSDKPath: String? = null, // Optional custom Swift SDK path
-    var swiftVersion: String = "main-snapshot-2025-12-17", // Swift version
-    var androidSdkVersion: String = "DEVELOPMENT-SNAPSHOT-2025-12-17-a_android" // SDK version
+    var swiftVersion: String = "main-snapshot-2026-01-07", // Swift version
+    var androidSdkVersion: String = "DEVELOPMENT-SNAPSHOT-2026-01-07-a_android" // SDK version
 )
 
 // Architecture definitions

--- a/swift-java-weather-app/weather-lib/build.gradle
+++ b/swift-java-weather-app/weather-lib/build.gradle
@@ -99,8 +99,8 @@ def swiftRuntimeLibs = [
     "swiftSynchronization"
 ]
 
-def sdkName = "swift-DEVELOPMENT-SNAPSHOT-2025-12-17-a_android.artifactbundle"
-def swiftVersion = "main-snapshot-2025-12-17"
+def sdkName = "swift-DEVELOPMENT-SNAPSHOT-2026-01-07-a_android.artifactbundle"
+def swiftVersion = "main-snapshot-2026-01-07"
 def minSdk = android.defaultConfig.minSdkVersion.apiLevel
 /**
  * Android ABIs and their Swift triple mappings


### PR DESCRIPTION
I noticed the [install instructions](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html) Swift SDK got updated but the gradle.build files still pointed to the old snapshots.

