### PR TITLE
Documentation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 local.properties
 jniLibs
 
+# generated documentation from swift package generate-documentation
+docs/
+
 # Kotlin Gradle plugin data
 # See https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects
 .kotlin/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "swift-android-examples",
+  products: [
+    .library(name: "SwiftAndroid", targets: ["SwiftAndroid"])
+  ],
+  dependencies: [
+    .package(
+      url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
+  ],
+  targets: [
+    .target(name: "SwiftAndroid")
+  ])

--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ Examples using raw JNI, without generated bridging sources:
 - **[hello-swift-raw-jni](hello-swift-raw-jni/)** - basic Swift integration that calls a Swift function.
 - **[hello-swift-raw-jni-callback](hello-swift-raw-jni-callback/)** - demonstrates bidirectional communication with Swift timer callbacks updating Android UI.
 - **[hello-swift-raw-jni-library](hello-swift-raw-jni-library/)** - shows how to package Swift code as a reusable Android library component.
+
+## Documentation
+
+The `Sources/SwiftAndroid/Documentation.docc` directory contains a DocC documentation catalog for Swift on Android. To build and preview it locally:
+
+```shell
+swift package generate-documentation --target SwiftAndroid --transform-for-static-hosting --output-path docs
+python3 -m http.server 8000 --directory docs
+```
+
+Then open <http://localhost:8000/documentation/swiftandroid> in your browser.

--- a/Sources/SwiftAndroid/Documentation.docc/BuildingForAndroid.md
+++ b/Sources/SwiftAndroid/Documentation.docc/BuildingForAndroid.md
@@ -1,0 +1,45 @@
+# Building for Android
+
+Cross-compile Swift code and package it into Android applications
+
+## Overview
+
+Swift on Android uses cross-compilation: you build on a macOS or Linux host, and the compiler produces native ARM or x86_64 binaries targeting Android.
+
+```shell
+$ swift build --swift-sdk aarch64-unknown-linux-android28
+```
+
+## Conditional compilation
+
+Use `#if os(Android)` to conditionalize code for Android:
+
+```swift
+#if os(Android)
+import Android
+#elseif canImport(Darwin)
+import Darwin
+#endif
+```
+
+## Foundation
+
+Foundation networking types require a separate import on non-Apple platforms:
+
+```swift
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+```
+
+## JNI integration
+
+Export Swift functions for JNI using `@_cdecl`:
+
+```swift
+@_cdecl("Java_com_example_MyClass_hello")
+func hello(env: UnsafeMutablePointer<JNIEnv>, thisObj: jobject) -> jstring {
+    return env.pointee.pointee.NewStringUTF(env, "Hello from Swift")!
+}
+```

--- a/Sources/SwiftAndroid/Documentation.docc/Documentation.md
+++ b/Sources/SwiftAndroid/Documentation.docc/Documentation.md
@@ -1,0 +1,19 @@
+# Swift on Android
+
+Use Swift to build native libraries and applications for Android
+
+@Metadata {
+  @TechnologyRoot
+}
+
+## Topics
+
+### Getting Started
+
+- <doc:GettingStarted>
+- <doc:BuildingForAndroid>
+
+### Guides
+
+- <doc:PortingPackages>
+- <doc:Integration>

--- a/Sources/SwiftAndroid/Documentation.docc/GettingStarted.md
+++ b/Sources/SwiftAndroid/Documentation.docc/GettingStarted.md
@@ -1,0 +1,36 @@
+# Getting Started
+
+Install the Swift toolchain, Android NDK, and Swift SDK for Android
+
+## Overview
+
+Development requires three components:
+
+1. **Swift Toolchain** -- install with [swiftly](https://github.com/swiftlang/swiftly): `swiftly install latest`
+2. **Android NDK** -- download from [developer.android.com](https://developer.android.com/ndk/downloads) (r27d+ recommended)
+3. **Swift SDK for Android** -- install with `swift sdk install` (see [swift.org](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html))
+
+## Install the SDK
+
+```shell
+$ swift sdk install https://download.swift.org/swift-6.1-release/android-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_android.artifactbundle.tar.gz
+$ swift sdk list
+```
+
+## Hello World
+
+```shell
+$ swift package init --type executable
+$ swift build --swift-sdk aarch64-unknown-linux-android28
+$ adb push .build/aarch64-unknown-linux-android28/debug/HelloWorld /data/local/tmp/
+$ adb shell /data/local/tmp/HelloWorld
+Hello, world!
+```
+
+## Target triples
+
+| Architecture | Triple |
+|---|---|
+| ARM64 | `aarch64-unknown-linux-android28` |
+| ARM32 | `armv7-unknown-linux-androideabi28` |
+| x86_64 | `x86_64-unknown-linux-android28` |

--- a/Sources/SwiftAndroid/Documentation.docc/GettingStarted.md
+++ b/Sources/SwiftAndroid/Documentation.docc/GettingStarted.md
@@ -10,13 +10,6 @@ Development requires three components:
 2. **Android NDK** -- download from [developer.android.com](https://developer.android.com/ndk/downloads) (r27d+ recommended)
 3. **Swift SDK for Android** -- install with `swift sdk install` (see [swift.org](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html))
 
-## Install the SDK
-
-```shell
-$ swift sdk install https://download.swift.org/swift-6.1-release/android-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_android.artifactbundle.tar.gz
-$ swift sdk list
-```
-
 ## Hello World
 
 ```shell

--- a/Sources/SwiftAndroid/Documentation.docc/Integration.md
+++ b/Sources/SwiftAndroid/Documentation.docc/Integration.md
@@ -21,20 +21,9 @@ tasks.register<Exec>("buildSwiftLibrary") {
 $ swift build --swift-sdk aarch64-unknown-linux-android28
 ```
 
-## Skip
-
-[Skip](https://skip.dev) transpiles Swift and SwiftUI to Kotlin and Jetpack Compose:
-
-```shell
-$ brew install skiptools/skip/skip
-$ skip android build
-$ skip android run
-```
-
 ## Resources
 
 - [Swift SDK for Android -- Getting Started](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html)
-- [Porting Swift Packages](https://skip.dev/docs/porting/)
 - [swift-java](https://github.com/swiftlang/swift-java) -- Java/Kotlin interop
-- [swift-android-action](https://github.com/skiptools/swift-android-action) -- GitHub Actions
+- [swift-android-action](https://github.com/marketplace/actions/swift-android-action) -- GitHub Actions
 - [Swift Forums](https://forums.swift.org/)

--- a/Sources/SwiftAndroid/Documentation.docc/Integration.md
+++ b/Sources/SwiftAndroid/Documentation.docc/Integration.md
@@ -1,0 +1,40 @@
+# Integration
+
+Integrate Swift builds with Android tooling and frameworks
+
+## Gradle
+
+Add a custom Gradle task to invoke `swift build` and copy the resulting `.so` into `jniLibs/`:
+
+```kotlin
+tasks.register<Exec>("buildSwiftLibrary") {
+    workingDir = file("${rootDir}/swift")
+    commandLine("swift", "build",
+        "--swift-sdk", "aarch64-unknown-linux-android28",
+        "-c", "release", "--static-swift-stdlib")
+}
+```
+
+## Swift Package Manager
+
+```shell
+$ swift build --swift-sdk aarch64-unknown-linux-android28
+```
+
+## Skip
+
+[Skip](https://skip.dev) transpiles Swift and SwiftUI to Kotlin and Jetpack Compose:
+
+```shell
+$ brew install skiptools/skip/skip
+$ skip android build
+$ skip android run
+```
+
+## Resources
+
+- [Swift SDK for Android -- Getting Started](https://www.swift.org/documentation/articles/swift-sdk-for-android-getting-started.html)
+- [Porting Swift Packages](https://skip.dev/docs/porting/)
+- [swift-java](https://github.com/swiftlang/swift-java) -- Java/Kotlin interop
+- [swift-android-action](https://github.com/skiptools/swift-android-action) -- GitHub Actions
+- [Swift Forums](https://forums.swift.org/)

--- a/Sources/SwiftAndroid/Documentation.docc/PortingPackages.md
+++ b/Sources/SwiftAndroid/Documentation.docc/PortingPackages.md
@@ -1,0 +1,41 @@
+# Porting Swift Packages to Android
+
+Adapt existing Swift packages to build and run on Android
+
+## Overview
+
+Many Swift packages build for Android with minimal changes. The typical process is: attempt a build, fix platform-specific code with conditional compilation, then test on a device.
+
+For a detailed walkthrough, see [Porting Swift Packages](https://skip.dev/docs/porting/) on the Skip website.
+
+## Good candidates
+
+- Business logic, algorithms, data structures
+- Networking and API clients
+- Parsers, formatters, encoders/decoders
+- SQLite and other database access
+
+## Conditional imports
+
+```swift
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Android)
+import Android
+#elseif canImport(Glibc)
+import Glibc
+#endif
+```
+
+## Testing on Android
+
+```shell
+$ skip android test
+```
+
+## CI with GitHub Actions
+
+```yaml
+- name: Test on Android
+  uses: skiptools/swift-android-action@v2
+```

--- a/Sources/SwiftAndroid/Documentation.docc/PortingPackages.md
+++ b/Sources/SwiftAndroid/Documentation.docc/PortingPackages.md
@@ -6,8 +6,6 @@ Adapt existing Swift packages to build and run on Android
 
 Many Swift packages build for Android with minimal changes. The typical process is: attempt a build, fix platform-specific code with conditional compilation, then test on a device.
 
-For a detailed walkthrough, see [Porting Swift Packages](https://skip.dev/docs/porting/) on the Skip website.
-
 ## Good candidates
 
 - Business logic, algorithms, data structures
@@ -27,15 +25,3 @@ import Glibc
 #endif
 ```
 
-## Testing on Android
-
-```shell
-$ skip android test
-```
-
-## CI with GitHub Actions
-
-```yaml
-- name: Test on Android
-  uses: skiptools/swift-android-action@v2
-```

--- a/Sources/SwiftAndroid/Empty.swift
+++ b/Sources/SwiftAndroid/Empty.swift
@@ -1,0 +1,1 @@
+// This file is included so SwiftPM considers the target to be a Swift target.


### PR DESCRIPTION
This PR adds support for documenting Swift on Android.

It follows the pattern of Swift embedded, whose documentation source at:
  https://github.com/swiftlang/swift-embedded-examples/tree/main/Sources/EmbeddedSwift/Documentation.docc
is published to:
  https://docs.swift.org/embedded/documentation/embedded/

Instructions for building and previewing the documentation locally are in the README.md.