### PR TITLE
Improve workflow caching and artifact naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
           echo "${{ steps.resolve-sdk.outputs.sdk_checksum }}  $HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}" | shasum -a 256 -c -
 
       - name: Cache Host Toolchain
-        id: cache-swift-sdk
+        id: cache-swiftly-toolchain
         uses: actions/cache@v5
         with:
           key: swiftly-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve-sdk.outputs.swift_install }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
         id: cache-ndk
         uses: actions/cache@v5
         with:
-          path: ~/android-ndk-${{ matrix.ndk_version }}
           key: android-ndk-${{ runner.os }}-${{ runner.arch }}-${{ matrix.ndk_version }}
+          path: ~/android-ndk-${{ matrix.ndk_version }}
 
       - name: Install Android NDK
         if: steps.cache-ndk.outputs.cache-hit != 'true'
@@ -153,8 +153,8 @@ jobs:
         id: cache-swift-sdk
         uses: actions/cache@v5
         with:
-          path: ~/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}
           key: ${{ steps.resolve-sdk.outputs.sdk_filename }}
+          path: ~/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}
 
       - name: Download Android Swift SDK artifact
         if: steps.cache-swift-sdk.outputs.cache-hit != 'true'
@@ -163,6 +163,16 @@ jobs:
           mkdir -p "$HOME/swift-sdk-cache"
           curl -L -o "$HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}" --retry 3 "${{ steps.resolve-sdk.outputs.sdk_url }}"
           echo "${{ steps.resolve-sdk.outputs.sdk_checksum }}  $HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}" | shasum -a 256 -c -
+
+      - name: Cache Host Toolchain
+        id: cache-swift-sdk
+        uses: actions/cache@v5
+        with:
+          key: swiftly-${{ runner.os }}-${{ runner.arch }}-${{ steps.resolve-sdk.outputs.swift_install }}
+          path: |
+            ~/Library/Developer/Toolchains
+            ~/.local/share/swiftly
+            ~/.local/bin/swiftly
 
       - name: Install host toolchain and Android Swift SDK
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
           echo "${{ steps.resolve-sdk.outputs.sdk_checksum }}  $HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}" | shasum -a 256 -c -
 
       - name: Cache Host Toolchain
+        # Disabled because we are overflowing the 10GB GitHub cache limit with this
+        # https://github.com/swiftlang/swift-android-examples/pull/44#discussion_r3236006987
+        if: false
         id: cache-swiftly-toolchain
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: apks-${{ matrix.os }}-${{ matrix.swift_version }}-${{ matrix.ndk_version }}
+          name: apks-${{ matrix.os }}-${{ matrix.swift_version }}-${{ matrix.ndk_version }}-${{ matrix.configuration }}
           path: '**/build/outputs/apk/**/*.apk'
           if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,10 @@ jobs:
       - name: Set ANDROID_NDK_HOME
         run: echo "ANDROID_NDK_HOME=$HOME/android-ndk-${NDK_VERSION}" >> "$GITHUB_ENV"
 
-      - name: Install Android Swift SDK and matching host toolchain
-        # Looks up the Android Swift SDK URL and checksum from the swift.org
-        # install API and installs it via `swift sdk install`.
+      - name: Resolve Android Swift SDK download URL
+        id: resolve-sdk
+        # Look up the Android Swift SDK URL and checksum from the swift.org
+        # install API.
         run: |
           set -euxo pipefail
           case "$SWIFT_VERSION" in
@@ -132,13 +133,13 @@ jobs:
           swift_install=${swift_install#swift-}
           swift_install=${swift_install/-RELEASE/}
 
-          echo "Installing Android Swift SDK and host toolchain"
-          echo "  tag:      $swift_install"
-          echo "  url:      $sdk_url"
-          echo "  checksum: $sdk_checksum"
-          swiftly install "${swift_install}"
-          swift sdk install "$sdk_url" --checksum "$sdk_checksum"
-          swift sdk list
+          sdk_filename="${snapshot_tag}_android.artifactbundle.tar.gz"
+
+          echo "snapshot_tag=${snapshot_tag}" >> "$GITHUB_OUTPUT"
+          echo "sdk_url=${sdk_url}" >> "$GITHUB_OUTPUT"
+          echo "sdk_checksum=${sdk_checksum}" >> "$GITHUB_OUTPUT"
+          echo "swift_install=${swift_install}" >> "$GITHUB_OUTPUT"
+          echo "sdk_filename=${sdk_filename}" >> "$GITHUB_OUTPUT"
 
           # Override the matrix-supplied SWIFT_VERSION (e.g. "6.3") with the
           # resolved patch version (e.g. "6.3.1") so the gradle scripts pick up
@@ -147,6 +148,32 @@ jobs:
           # same reason.
           echo "SWIFT_VERSION=${swift_install}" >> "$GITHUB_ENV"
           echo "SWIFT_ANDROID_SDK_VERSION=${snapshot_tag#swift-}_android" >> "$GITHUB_ENV"
+
+      - name: Cache Android Swift SDK artifact
+        id: cache-swift-sdk
+        uses: actions/cache@v5
+        with:
+          path: ~/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}
+          key: ${{ steps.resolve-sdk.outputs.sdk_filename }}
+
+      - name: Download Android Swift SDK artifact
+        if: steps.cache-swift-sdk.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+          mkdir -p "$HOME/swift-sdk-cache"
+          curl -L -o "$HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}" --retry 3 "${{ steps.resolve-sdk.outputs.sdk_url }}"
+          echo "${{ steps.resolve-sdk.outputs.sdk_checksum }}  $HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}" | shasum -a 256 -c -
+
+      - name: Install host toolchain and Android Swift SDK
+        run: |
+          set -euxo pipefail
+          echo "Installing Android Swift SDK and host toolchain"
+          echo "  tag:      ${{ steps.resolve-sdk.outputs.swift_install }}"
+          echo "  file:     $HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}"
+          echo "  checksum: ${{ steps.resolve-sdk.outputs.sdk_checksum }}"
+          swiftly install "${{ steps.resolve-sdk.outputs.swift_install }}"
+          swift sdk install "$HOME/swift-sdk-cache/${{ steps.resolve-sdk.outputs.sdk_filename }}"
+          swift sdk list
 
       - name: Configure Swift Android SDK
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
       - name: Summarize APK artifacts
         if: always()
         run: |
-          echo "## APK Artifacts (os:${{ matrix.os }} / swift:${{ matrix.swift_version }} / ndk:${{ matrix.ndk_version }}) / configuration:${{ matrix.configuration }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "## APK Artifacts (os:${{ matrix.os }} / swift:${{ steps.resolve-sdk.outputs.swift_install }} / ndk:${{ matrix.ndk_version }} / configuration:${{ matrix.configuration }})" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Project | APK | Size |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---------|-----|------|" >> "$GITHUB_STEP_SUMMARY"
@@ -276,6 +276,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: apks-${{ matrix.os }}-${{ matrix.swift_version }}-${{ matrix.ndk_version }}-${{ matrix.configuration }}
+          name: apks-${{ matrix.os }}-${{ steps.resolve-sdk.outputs.swift_install }}-${{ matrix.ndk_version }}-${{ matrix.configuration }}
           path: '**/build/outputs/apk/**/*.apk'
           if-no-files-found: warn


### PR DESCRIPTION
This PR adds caching for the Swift SDK for Android as well as the corresponding host toolchain that is installed by swiftly, which should help reduce the amount of network traffic (and associated CI flakiness potential) when setting up the host toolchain + swift sdk.

We also include the matrix.configuration in the artifact name in workflow to disambiguate multiple artifacts, which  should solve the workflow [error](https://github.com/swiftlang/swift-android-examples/actions/runs/25779764322/job/75719652907):

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

