### PR TITLE
Fix installation of local swift-java maven artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,23 @@ jobs:
               --project-dir .build/checkouts/swift-java \
               :SwiftKitCore:publishToMavenLocal
 
+          # Debug: list everything that actually landed in the local Maven
+          # repository so we can see why org.swift.swiftkit:swiftkit-core:
+          # 1.0-SNAPSHOT may be missing.
+          maven_local="${HOME}/.m2/repository"
+          echo "::group::Local Maven repository contents (${maven_local})"
+          if [[ -d "${maven_local}" ]]; then
+            # Every published artifact has a .pom; list them to enumerate the
+            # installed group:artifact:version coordinates.
+            find "${maven_local}" -name '*.pom' -print | sort
+            echo "--- swiftkit-core specifically ---"
+            find "${maven_local}" -path '*swift*swiftkit*' -print | sort \
+              || echo "No org.swift.swiftkit artifacts found in local Maven repository"
+          else
+            echo "Local Maven repository does not exist at ${maven_local}"
+          fi
+          echo "::endgroup::"
+
       - name: Build hello-swift-raw-jni APK
         run: ./gradlew :hello-swift-raw-jni:assemble${{ matrix.configuration }} --stacktrace
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,8 @@ jobs:
 
       - name: Publish swift-java packages to local Maven
         # The hashing-lib, weather-lib, and hello-cpp-swift/swift-lib modules
-        # depend on org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT, which is not
+        # depend on org.swift.swiftkit:swiftkit-core (via the "+" wildcard, so
+        # they pick up whatever version swift-java publishes), which is not
         # published to a public Maven repo. The hashing-lib README documents
         # publishing it to mavenLocal from the swift-java checkout that
         # SwiftPM resolves into .build/checkouts/swift-java.
@@ -227,8 +228,8 @@ jobs:
               :SwiftKitCore:publishToMavenLocal
 
           # Debug: list everything that actually landed in the local Maven
-          # repository so we can see why org.swift.swiftkit:swiftkit-core:
-          # 1.0-SNAPSHOT may be missing.
+          # repository so we can see which org.swift.swiftkit:swiftkit-core
+          # version got published (the modules depend on the "+" wildcard).
           maven_local="${HOME}/.m2/repository"
           echo "::group::Local Maven repository contents (${maven_local})"
           if [[ -d "${maven_local}" ]]; then

--- a/hello-cpp-swift/app/build.gradle.kts
+++ b/hello-cpp-swift/app/build.gradle.kts
@@ -56,6 +56,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.constraintlayout)
-    implementation("org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT")
+    implementation("org.swift.swiftkit:swiftkit-core:+")
     implementation(project(":hello-cpp-swift:swift-lib"))
 }

--- a/hello-cpp-swift/swift-lib/build.gradle
+++ b/hello-cpp-swift/swift-lib/build.gradle
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation('org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT')
+    implementation('org.swift.swiftkit:swiftkit-core:+')
 }
 
 def getSwiftlyPath() {

--- a/hello-swift-java/hashing-app/build.gradle.kts
+++ b/hello-swift-java/hashing-app/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation("org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT")
+    implementation("org.swift.swiftkit:swiftkit-core:+")
     implementation(project(":hello-swift-java-hashing-lib"))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/hello-swift-java/hashing-lib/build.gradle
+++ b/hello-swift-java/hashing-lib/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    implementation('org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT')
+    implementation('org.swift.swiftkit:swiftkit-core:+')
 }
 
 // Helper function to get swiftly executable path

--- a/swift-java-weather-app/weather-app/build.gradle.kts
+++ b/swift-java-weather-app/weather-app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation("com.google.android.gms:play-services-location:21.0.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
-    implementation("org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT")
+    implementation("org.swift.swiftkit:swiftkit-core:+")
     implementation(project(":swift-java-weather-app-weather-lib"))
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/swift-java-weather-app/weather-lib/build.gradle
+++ b/swift-java-weather-app/weather-lib/build.gradle
@@ -36,7 +36,7 @@ android {
 }
 
 dependencies {
-    implementation('org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT')
+    implementation('org.swift.swiftkit:swiftkit-core:+')
 }
 
 // Helper function to get swiftly executable path


### PR DESCRIPTION
The various gradle build scripts in the examples here had a hardwired dependency on `org.swift.swiftkit:swiftkit-core:1.0-SNAPSHOT`, but as of https://github.com/swiftlang/swift-java/pull/794, the `swiftkit-core` dependency is using the tagged release version.

This PR updates the dependencies to simply us `org.swift.swiftkit:swiftkit-core:+` to match whatever was installed in the local maven repository by the "Publish swift-java packages to local Maven" step.