### PR TITLE
Give the Swift on Android landing page a display name and abstract

### DIFF
--- a/Sources/SwiftAndroid/SwiftAndroid.docc/SwiftAndroid.md
+++ b/Sources/SwiftAndroid/SwiftAndroid.docc/SwiftAndroid.md
@@ -1,6 +1,10 @@
-# Swift on Android
+# ``SwiftAndroid``
 
-Use Swift to build native libraries and applications for Android
+Build native libraries and apps for Android with Swift, from toolchain setup to integrating with Android tooling.
+
+@Metadata {
+    @DisplayName("Swift for Android")
+}
 
 ## Topics
 


### PR DESCRIPTION
## Motivation

In the aggregated swift.org documentation, the Android guide's landing page renders with the smashed-together module symbol name (`SwiftAndroid`) and no abstract. The root article used a plain-text heading (`# Swift on Android`), which detaches it from the module symbol, so the built module page had no abstract and none of the article content.

## Changes

- Switch the landing page heading to the module symbol reference (```SwiftAndroid```) so the article's abstract and content attach to the module page.
- Add `@Metadata { @DisplayName("Swift for Android") }` so the page and navigation read as "Swift for Android" instead of "SwiftAndroid". This also parallels the "Swift for WebAssembly" landing page in the same Platforms navigation group.
- Add a concise abstract: "Build native libraries and apps for Android with Swift, from toolchain setup to integrating with Android tooling."

## Validation

`swift package generate-documentation --target SwiftAndroid --analyze --warnings-as-errors` builds successfully. The generated module page now shows the title "Swift for Android" and the abstract.

This makes the content fit in more effectively with a combined Swift documentation set.