### PR TITLE
Bump NDK matrix r30-beta1 to r30-beta2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         swift_version: ['6.3', 'nightly-6.3', 'nightly-main']
-        ndk_version: ['r27d', 'r29', 'r30-beta1']
+        ndk_version: ['r27d', 'r29', 'r30-beta2']
         os: ['ubuntu-latest', 'macos-latest']
         configuration: ['Debug', 'Release']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR bumps the "ndk30-beta1" matrix option to "ndk30-beta2" to verify that the Android examples can all build against the latest NDK.

Changelog at: https://github.com/android/ndk/wiki/Changelog-r30