### PR TITLE
Show "Platforms" eyebrow and match nav display name on landing page

### DIFF
--- a/Sources/SwiftAndroid/SwiftAndroid.docc/SwiftAndroid.md
+++ b/Sources/SwiftAndroid/SwiftAndroid.docc/SwiftAndroid.md
@@ -3,7 +3,8 @@
 Build native libraries and apps for Android with Swift, from toolchain setup to integrating with Android tooling.
 
 @Metadata {
-    @DisplayName("Swift for Android")
+    @DisplayName("Android")
+    @TitleHeading("Platforms")
 }
 
 ## Topics


### PR DESCRIPTION
## Summary
- This module belongs to the "Platforms" nav group on the combined Swift docs site, but the landing page didn't show that as an eyebrow above the title. Adds `@TitleHeading("Platforms")`.
- The landing page's `@DisplayName` was "Swift for Android", while the nav label is "Android". Updates the display name to match so the in-content title agrees with the nav.

## Test plan
- [x] `swift package generate-documentation --target SwiftAndroid --analyze --warnings-as-errors` builds cleanly (no new warnings)